### PR TITLE
Defined routes for frontend integration

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -15,8 +15,8 @@ Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanc
 
 Route::post('/register', [AuthController::class, 'register']);
 
-Route::get('/', [ServiceController::class, 'index']);
-Route::post('/', [OrderController::class, 'store']);
+Route::get('/services', [ServiceController::class, 'index']);
+Route::post('/orders', [OrderController::class, 'store']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/users', function () {


### PR DESCRIPTION
### Overview
- This PR intends to define the routes for the requests coming from the frontend. This will serve as the path to retrieve and store data from the database.

### Updates made
- In the `api.php` file, two routes were created for the `GET` and `POST` requests from the frontend. 
- The `GET` route will retrieve some columns from the `SERVICES` table in the database.
- The `POST` route will store the order details from the frontend to the `ORDERS` table in the database.